### PR TITLE
Fixed delayed startup completion.

### DIFF
--- a/CatLib/Runtime/UnityApplication.cs
+++ b/CatLib/Runtime/UnityApplication.cs
@@ -10,6 +10,7 @@
  */
 
 using System;
+using System.Collections;
 using UnityEngine;
 
 namespace CatLib
@@ -47,7 +48,7 @@ namespace CatLib
         {
             if (Behaviour)
             {
-                Behaviour.StartCoroutine(CoroutineInit());
+                Behaviour.StartCoroutine(InitWithUnityCoroutine());
                 return;
             }
             base.Init();
@@ -84,6 +85,31 @@ namespace CatLib
         protected override bool IsUnableType(Type type)
         {
             return typeof(Component).IsAssignableFrom(type) || base.IsUnableType(type);
+        }
+
+        /// <summary>
+        /// 使用Unity协同程序初始化服务提供者.
+        /// </summary>
+        /// <returns>协同程序</returns>
+        /// <see cref="https://github.com/CatLib/CatLib/issues/38"/>
+        private IEnumerator InitWithUnityCoroutine()
+        {
+            var coroutine = CoroutineInit();
+            while (coroutine.MoveNext())
+            {
+                if (!(coroutine.Current is IEnumerator frameworkCoroutine))
+                {
+                    continue;
+                }
+
+                while (frameworkCoroutine.MoveNext())
+                {
+                    if (frameworkCoroutine.Current is IEnumerator logicCoroutine)
+                    {
+                        yield return logicCoroutine;
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
| Q | A |
|----|----|
| Branch? |  v1.4  |
| Bug fix? | Yes(#38 ) |
| New feature? | No |
| Deprecations? | No |
| Tests pass? | N/A |
| License? | N/A |
| Doc pr? | N/A |

Fixing the adding a service provider will cause the framework to delay the start of one frame.

This is because Unity waits for a frame to execute when the iterator returns null. 

If the service provider implements the `ICoroutineInit` interface, it will still delay one frame of execution.  No delay when the interface is not implemented.